### PR TITLE
Bigquery col alias override

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -276,7 +276,7 @@ impl Dialect for BigQueryDialect {
     ) -> Result<Option<String>> {
         // Check if alias contains any special characters not supported by BigQuery col names
         // https://cloud.google.com/bigquery/docs/schemas#flexible-column-names
-        let special_chars = [
+        let special_chars: [char; 20] = [
             '!', '"', '$', '(', ')', '*', ',', '.', '/', ';', '?', '@', '[', '\\', ']',
             '^', '`', '{', '}', '~',
         ];
@@ -284,12 +284,10 @@ impl Dialect for BigQueryDialect {
         if alias.chars().any(|c| special_chars.contains(&c)) {
             let mut encoded_name = String::new();
             for c in alias.chars() {
-                match c {
-                    '!' | '"' | '$' | '(' | ')' | '*' | ',' | '.' | '/' | ';' | '?'
-                    | '@' | '[' | '\\' | ']' | '^' | '`' | '{' | '}' | '~' => {
-                        encoded_name.push_str(&format!("_{}", c as u32));
-                    }
-                    _ => encoded_name.push(c),
+                if special_chars.contains(&c) {
+                    encoded_name.push_str(&format!("_{}", c as u32));
+                } else {
+                    encoded_name.push(c);
                 }
             }
             Ok(Some(encoded_name))

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -279,11 +279,12 @@ impl Dialect for BigQueryDialect {
     ) -> Result<Option<String>> {
         // Check if alias contains any special characters not supported by BigQuery col names
         // https://cloud.google.com/bigquery/docs/schemas#flexible-column-names
-        if alias.contains(|c| match c {
-            '!' | '"' | '$' | '(' | ')' | '*' | ',' | '.' | '/' | ';' | '?' | '@'
-            | '[' | '\\' | ']' | '^' | '`' | '{' | '}' | '~' => true,
-            _ => false,
-        }) {
+        if alias.contains(
+            &[
+                '!', '"', '$', '(', ')', '*', ',', '.', '/', ';', '?', '@', '[', '\\',
+                ']', '^', '`', '{', '}', '~',
+            ][..],
+        ) {
             Ok(Some(self.col_alias_generator.next("col")))
         } else {
             Ok(Some(alias.to_string()))

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -157,11 +157,7 @@ pub trait Dialect: Send + Sync {
     /// Allows the dialect to override column alias unparsing if the dialect has specific rules.
     /// Returns None if the default unparsing should be used, or Some(String) if there is
     /// a custom implementation for the alias.
-    fn col_alias_overrides(
-        &self,
-        _unparser: &Unparser,
-        _alias: &str,
-    ) -> Result<Option<String>> {
+    fn col_alias_overrides(&self, _alias: &str) -> Result<Option<String>> {
         Ok(None)
     }
 
@@ -272,11 +268,7 @@ impl Dialect for BigQueryDialect {
         Some('`')
     }
 
-    fn col_alias_overrides(
-        &self,
-        _unparser: &Unparser,
-        alias: &str,
-    ) -> Result<Option<String>> {
+    fn col_alias_overrides(&self, alias: &str) -> Result<Option<String>> {
         // Check if alias contains any special characters not supported by BigQuery col names
         // https://cloud.google.com/bigquery/docs/schemas#flexible-column-names
         let special_chars: [char; 20] = [

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -154,6 +154,9 @@ pub trait Dialect: Send + Sync {
         Ok(None)
     }
 
+    /// Allows the dialect to override column alias unparsing if the dialect has specific rules.
+    /// Returns None if the default unparsing should be used, or Some(String) if there is
+    /// a custom implementation for the alias.
     fn col_alias_overrides(
         &self,
         _unparser: &Unparser,

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -677,7 +677,7 @@ impl Unparser<'_> {
     fn col_to_sql(&self, col: &Column) -> Result<ast::Expr> {
         // Replace the column name if the dialect has an override
         let col_name = match self.dialect.col_alias_overrides(&col.name)? {
-            Some(encoded_name) => encoded_name,
+            Some(rewritten_name) => rewritten_name,
             None => col.name.to_string(),
         };
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -675,7 +675,7 @@ impl Unparser<'_> {
     }
 
     fn col_to_sql(&self, col: &Column) -> Result<ast::Expr> {
-        // Encode column name if it contains special characters
+        // Replace the column name if the dialect has an override
         let col_name = match self.dialect.col_alias_overrides(self, &col.name)? {
             Some(encoded_name) => encoded_name,
             None => col.name.to_string(),

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -676,7 +676,7 @@ impl Unparser<'_> {
 
     fn col_to_sql(&self, col: &Column) -> Result<ast::Expr> {
         // Replace the column name if the dialect has an override
-        let col_name = match self.dialect.col_alias_overrides(self, &col.name)? {
+        let col_name = match self.dialect.col_alias_overrides(&col.name)? {
             Some(encoded_name) => encoded_name,
             None => col.name.to_string(),
         };

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1044,10 +1044,10 @@ impl Unparser<'_> {
                     name.to_string()
                 };
 
-                return Ok(ast::SelectItem::ExprWithAlias {
+                Ok(ast::SelectItem::ExprWithAlias {
                     expr: inner,
                     alias: self.new_ident_quoted_if_needs(alias_name),
-                });
+                })
             }
             _ => {
                 let inner = self.expr_to_sql(expr)?;

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1036,13 +1036,12 @@ impl Unparser<'_> {
                 let inner = self.expr_to_sql(expr)?;
 
                 // Determine the alias name to use
-                let alias_name = if let Some(new_name) =
-                    self.dialect.col_alias_overrides(self, name)?
-                {
-                    new_name.to_string()
-                } else {
-                    name.to_string()
-                };
+                let alias_name =
+                    if let Some(new_name) = self.dialect.col_alias_overrides(name)? {
+                        new_name.to_string()
+                    } else {
+                        name.to_string()
+                    };
 
                 Ok(ast::SelectItem::ExprWithAlias {
                     expr: inner,

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1036,16 +1036,17 @@ impl Unparser<'_> {
                 let inner = self.expr_to_sql(expr)?;
 
                 // Determine the alias name to use
-                let alias_name =
-                    if let Some(new_name) = self.dialect.col_alias_overrides(name)? {
-                        new_name.to_string()
-                    } else {
-                        name.to_string()
-                    };
+                let col_name = if let Some(rewritten_name) =
+                    self.dialect.col_alias_overrides(name)?
+                {
+                    rewritten_name.to_string()
+                } else {
+                    name.to_string()
+                };
 
                 Ok(ast::SelectItem::ExprWithAlias {
                     expr: inner,
-                    alias: self.new_ident_quoted_if_needs(alias_name),
+                    alias: self.new_ident_quoted_if_needs(col_name),
                 })
             }
             _ => {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1034,10 +1034,17 @@ impl Unparser<'_> {
         match expr {
             Expr::Alias(Alias { expr, name, .. }) => {
                 let inner = self.expr_to_sql(expr)?;
-
-                Ok(ast::SelectItem::ExprWithAlias {
+                
+                // Determine the alias name to use
+                let alias_name = if let Some(new_name) = self.dialect.col_alias_overrides(self, name)? {
+                    new_name.to_string()
+                } else {
+                    name.to_string()
+                };
+            
+                return Ok(ast::SelectItem::ExprWithAlias {
                     expr: inner,
-                    alias: self.new_ident_quoted_if_needs(name.to_string()),
+                    alias: self.new_ident_quoted_if_needs(alias_name),
                 })
             }
             _ => {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1034,18 +1034,20 @@ impl Unparser<'_> {
         match expr {
             Expr::Alias(Alias { expr, name, .. }) => {
                 let inner = self.expr_to_sql(expr)?;
-                
+
                 // Determine the alias name to use
-                let alias_name = if let Some(new_name) = self.dialect.col_alias_overrides(self, name)? {
+                let alias_name = if let Some(new_name) =
+                    self.dialect.col_alias_overrides(self, name)?
+                {
                     new_name.to_string()
                 } else {
                     name.to_string()
                 };
-            
+
                 return Ok(ast::SelectItem::ExprWithAlias {
                     expr: inner,
                     alias: self.new_ident_quoted_if_needs(alias_name),
-                })
+                });
             }
             _ => {
                 let inner = self.expr_to_sql(expr)?;

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -539,19 +539,25 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
         },
         TestStatementWithDialect {
             sql: "select min(*) as \"min(*)\" from (select 1 as a)",
-            expected: "SELECT min(*) AS `col_1` FROM (SELECT 1 AS `a`)",
+            expected: "SELECT min(*) AS `min_40_42_41` FROM (SELECT 1 AS `a`)",
             parser_dialect: Box::new(PostgreSqlDialect {}),
             unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
         },
         TestStatementWithDialect {
             sql: "select a as \"a*\", b as \"b@\" from (select 1 as a , 2 as b)",
-            expected: "SELECT `a` AS `col_1`, `b` AS `col_2` FROM (SELECT 1 AS `a`, 2 AS `b`)",
+            expected: "SELECT `a` AS `a_42`, `b` AS `b_64` FROM (SELECT 1 AS `a`, 2 AS `b`)",
             parser_dialect: Box::new(PostgreSqlDialect {}),
             unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
         },
         TestStatementWithDialect {
             sql: "select a as \"a*\", b , c as \"c@\" from (select 1 as a , 2 as b, 3 as c)",
-            expected: "SELECT `a` AS `col_1`, `b`, `c` AS `col_2` FROM (SELECT 1 AS `a`, 2 AS `b`, 3 AS `c`)",
+            expected: "SELECT `a` AS `a_42`, `b`, `c` AS `c_64` FROM (SELECT 1 AS `a`, 2 AS `b`, 3 AS `c`)",
+            parser_dialect: Box::new(PostgreSqlDialect {}),
+            unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
+        },
+        TestStatementWithDialect {
+            sql: "select * from (select a as \"a*\", b as \"b@\" from (select 1 as a , 2 as b)) where \"a*\" = 1",
+            expected: "SELECT * FROM (SELECT `a` AS `a_42`, `b` AS `b_64` FROM (SELECT 1 AS `a`, 2 AS `b`)) WHERE (`a_42` = 1)",
             parser_dialect: Box::new(PostgreSqlDialect {}),
             unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
         },

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -32,7 +32,7 @@ use datafusion_functions_window::rank::rank_udwf;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
     CustomDialectBuilder, DefaultDialect as UnparserDefaultDialect, DefaultDialect,
-    Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect, SqliteDialect,
+    Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect, SqliteDialect, BigQueryDialect as UnparserBigqueryDialect
 };
 use datafusion_sql::unparser::{expr_to_sql, plan_to_sql, Unparser};
 use sqlparser::ast::Statement;
@@ -54,7 +54,7 @@ use datafusion_sql::unparser::extension_unparser::{
     UnparseToStatementResult, UnparseWithinStatementResult,
     UserDefinedLogicalNodeUnparser,
 };
-use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect};
+use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect, PostgreSqlDialect};
 use sqlparser::parser::Parser;
 
 #[test]
@@ -536,6 +536,12 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             parser_dialect: Box::new(GenericDialect {}),
             unparser_dialect: Box::new(SqliteDialect {}),
         },
+        TestStatementWithDialect {
+            sql: "select min(*) as \"min(*)\" from (select 1 as a)",
+            expected: "SELECT min(*) AS `col_1` FROM (SELECT 1 AS `a`)",
+            parser_dialect: Box::new(PostgreSqlDialect {}),
+            unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
+        },  
         TestStatementWithDialect {
             sql: "SELECT * FROM UNNEST([1,2,3])",
             expected: r#"SELECT * FROM (SELECT UNNEST([1, 2, 3]) AS "UNNEST(make_array(Int64(1),Int64(2),Int64(3)))")"#,

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -31,8 +31,9 @@ use datafusion_functions_nested::map::map_udf;
 use datafusion_functions_window::rank::rank_udwf;
 use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
-    CustomDialectBuilder, DefaultDialect as UnparserDefaultDialect, DefaultDialect,
-    Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect, SqliteDialect, BigQueryDialect as UnparserBigqueryDialect
+    BigQueryDialect as UnparserBigqueryDialect, CustomDialectBuilder,
+    DefaultDialect as UnparserDefaultDialect, DefaultDialect, Dialect as UnparserDialect,
+    MySqlDialect as UnparserMySqlDialect, SqliteDialect,
 };
 use datafusion_sql::unparser::{expr_to_sql, plan_to_sql, Unparser};
 use sqlparser::ast::Statement;
@@ -283,7 +284,7 @@ fn roundtrip_crossjoin() -> Result<()> {
 }
 
 #[test]
-fn roundtrip_statement_with_dialect() -> Result<()> { 
+fn roundtrip_statement_with_dialect() -> Result<()> {
     struct TestStatementWithDialect {
         sql: &'static str,
         expected: &'static str,
@@ -541,7 +542,7 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             expected: "SELECT min(*) AS `col_1` FROM (SELECT 1 AS `a`)",
             parser_dialect: Box::new(PostgreSqlDialect {}),
             unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
-        }, 
+        },
         TestStatementWithDialect {
             sql: "select a as \"a*\", b as \"b@\" from (select 1 as a , 2 as b)",
             expected: "SELECT `a` AS `col_1`, `b` AS `col_2` FROM (SELECT 1 AS `a`, 2 AS `b`)",

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -283,7 +283,7 @@ fn roundtrip_crossjoin() -> Result<()> {
 }
 
 #[test]
-fn roundtrip_statement_with_dialect() -> Result<()> {
+fn roundtrip_statement_with_dialect() -> Result<()> { 
     struct TestStatementWithDialect {
         sql: &'static str,
         expected: &'static str,
@@ -541,7 +541,19 @@ fn roundtrip_statement_with_dialect() -> Result<()> {
             expected: "SELECT min(*) AS `col_1` FROM (SELECT 1 AS `a`)",
             parser_dialect: Box::new(PostgreSqlDialect {}),
             unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
-        },  
+        }, 
+        TestStatementWithDialect {
+            sql: "select a as \"a*\", b as \"b@\" from (select 1 as a , 2 as b)",
+            expected: "SELECT `a` AS `col_1`, `b` AS `col_2` FROM (SELECT 1 AS `a`, 2 AS `b`)",
+            parser_dialect: Box::new(PostgreSqlDialect {}),
+            unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
+        },
+        TestStatementWithDialect {
+            sql: "select a as \"a*\", b , c as \"c@\" from (select 1 as a , 2 as b, 3 as c)",
+            expected: "SELECT `a` AS `col_1`, `b`, `c` AS `col_2` FROM (SELECT 1 AS `a`, 2 AS `b`, 3 AS `c`)",
+            parser_dialect: Box::new(PostgreSqlDialect {}),
+            unparser_dialect: Box::new(UnparserBigqueryDialect::new()),
+        },
         TestStatementWithDialect {
             sql: "SELECT * FROM UNNEST([1,2,3])",
             expected: r#"SELECT * FROM (SELECT UNNEST([1, 2, 3]) AS "UNNEST(make_array(Int64(1),Int64(2),Int64(3)))")"#,


### PR DESCRIPTION
## Which issue does this PR close?
https://github.com/Canner/wren-engine/issues/1089

## Rationale for this change
Add an additional unparser rule for every dialect to allow dialects to override column aliases.

## What changes are included in this PR?
Rewrite BigQuery column aliases.

## Are these changes tested?
In datafusion/sql/tests/cases/plan_to_sql.rs `roundtrip_statement_with_dialect`.