### PR TITLE
introduce `to_unicode_string_literal` for unparser dialect

### DIFF
--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -204,6 +204,13 @@ pub trait Dialect: Send + Sync {
     fn col_alias_overrides(&self, _alias: &str) -> Result<Option<String>> {
         Ok(None)
     }
+
+    /// Allow the dialect to unparse a string literal as a national string literal.
+    /// Some dialects like MSSQL require national string literals(N'datafusion資料融合') to be prefixed with N
+    /// to support Unicode characters.
+    fn to_unicode_string_literal(&self, _s: &str) -> Option<ast::Expr> {
+        None
+    }
 }
 
 /// `IntervalStyle` to use for unparsing
@@ -547,6 +554,25 @@ impl BigQueryDialect {
     #[must_use]
     pub fn new() -> Self {
         Self {}
+    }
+}
+
+#[derive(Default)]
+pub struct MsSqlDialect {}
+
+impl Dialect for MsSqlDialect {
+    fn identifier_quote_style(&self, _: &str) -> Option<char> {
+        Some('[')
+    }
+
+    fn to_unicode_string_literal(&self, s: &str) -> Option<ast::Expr> {
+        if !s.is_ascii() {
+            Some(ast::Expr::value(ast::Value::NationalStringLiteral(
+                s.to_string(),
+            )))
+        } else {
+            None
+        }
     }
 }
 

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -1217,18 +1217,17 @@ impl Unparser<'_> {
                 Ok(ast::Expr::value(ast::Value::Number(ui.to_string(), false)))
             }
             ScalarValue::UInt64(None) => Ok(ast::Expr::value(ast::Value::Null)),
-            ScalarValue::Utf8(Some(str)) => {
+            ScalarValue::Utf8(Some(str))
+            | ScalarValue::Utf8View(Some(str))
+            | ScalarValue::LargeUtf8(Some(str)) => {
+                if let Some(expr) = self.dialect.to_unicode_string_literal(str) {
+                    return Ok(expr);
+                }
                 Ok(ast::Expr::value(SingleQuotedString(str.to_string())))
             }
-            ScalarValue::Utf8(None) => Ok(ast::Expr::value(ast::Value::Null)),
-            ScalarValue::Utf8View(Some(str)) => {
-                Ok(ast::Expr::value(SingleQuotedString(str.to_string())))
-            }
-            ScalarValue::Utf8View(None) => Ok(ast::Expr::value(ast::Value::Null)),
-            ScalarValue::LargeUtf8(Some(str)) => {
-                Ok(ast::Expr::value(SingleQuotedString(str.to_string())))
-            }
-            ScalarValue::LargeUtf8(None) => Ok(ast::Expr::value(ast::Value::Null)),
+            ScalarValue::Utf8(None)
+            | ScalarValue::Utf8View(None)
+            | ScalarValue::LargeUtf8(None) => Ok(ast::Expr::value(ast::Value::Null)),
             ScalarValue::Binary(Some(_)) => not_impl_err!("Unsupported scalar: {v:?}"),
             ScalarValue::Binary(None) => Ok(ast::Expr::value(ast::Value::Null)),
             ScalarValue::BinaryView(Some(_)) => {
@@ -1743,7 +1742,7 @@ mod tests {
     use std::ops::{Add, Sub};
     use std::{any::Any, sync::Arc, vec};
 
-    use crate::unparser::dialect::SqliteDialect;
+    use crate::unparser::dialect::{MsSqlDialect, SqliteDialect};
     use arrow::array::{LargeListArray, ListArray};
     use arrow::datatypes::{DataType::Int8, Field, Int32Type, Schema, TimeUnit};
     use ast::ObjectName;
@@ -2864,6 +2863,39 @@ mod tests {
 
             assert_eq!(actual, expected);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_mssql_dialect_national_literal() -> Result<()> {
+        let dialect = MsSqlDialect::default();
+        let unparser = Unparser::new(&dialect);
+
+        let expr =
+            Expr::Literal(ScalarValue::Utf8(Some("national string".to_string())), None);
+        let ast = unparser.expr_to_sql(&expr)?;
+        // no unicode characters, so no prefixed with N
+        assert_eq!(ast.to_string(), "'national string'");
+
+        let expr = Expr::Literal(
+            ScalarValue::Utf8(Some("datafusion資料融合".to_string())),
+            None,
+        );
+
+        let ast = unparser.expr_to_sql(&expr)?;
+        // contain unicode characters, so prefixed with N
+        assert_eq!(ast.to_string(), "N'datafusion資料融合'");
+
+        let dialect = DefaultDialect {};
+        let unparser = Unparser::new(&dialect);
+
+        let expr = Expr::Literal(
+            ScalarValue::Utf8(Some("datafusion資料融合".to_string())),
+            None,
+        );
+        let ast = unparser.expr_to_sql(&expr)?;
+        // no N prefix in default dialect
+        assert_eq!(ast.to_string(), "'datafusion資料融合'");
         Ok(())
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change
For MSSQL, if a string literal contains some Unicode characters, it should use the national string literal (`N'xx中文'`). If using the normal string literal, the value can't be presented well.
```
SELECT 'xx中文' = N'xx中文'
-----
False
```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
add the new method for the unparser dialect
```rust
    /// Allow the dialect to unparse a string literal as a national string literal.
    /// Some dialects like MSSQL require national string literals(N'datafusion資料融合') to be prefixed with N
    /// to support Unicode characters.
    fn to_unicode_string_literal(&self, _s: &str) -> Option<ast::Expr> {
        None
    }
```
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?
unit test
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
