### PR TITLE
Support unparsing UNNEST plan for Snowflake dialect

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -21,6 +21,8 @@ use std::ops::ControlFlow;
 use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{self, visit_expressions_mut, OrderByKind, SelectFlavor};
 
+use crate::unparser::utils::UNNAMED_FLATTEN_SUBQUERY_PREFIX;
+
 #[derive(Clone)]
 pub struct QueryBuilder {
     with: Option<ast::With>,
@@ -404,10 +406,12 @@ pub struct RelationBuilder {
 #[allow(dead_code)]
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
-enum TableFactorBuilder {
+pub(crate) enum TableFactorBuilder {
     Table(TableRelationBuilder),
     Derived(DerivedRelationBuilder),
     Unnest(UnnestRelationBuilder),
+    Function(FunctionRelationBuilder),
+    TableFunction(TableFunctionRelationBuilder),
     Empty,
 }
 
@@ -430,6 +434,16 @@ impl RelationBuilder {
         self
     }
 
+    pub fn function(&mut self, value: FunctionRelationBuilder) -> &mut Self {
+        self.relation = Some(TableFactorBuilder::Function(value));
+        self
+    }
+
+    pub fn table_function(&mut self, value: TableFunctionRelationBuilder) -> &mut Self {
+        self.relation = Some(TableFactorBuilder::TableFunction(value));
+        self
+    }
+
     pub fn empty(&mut self) -> &mut Self {
         self.relation = Some(TableFactorBuilder::Empty);
         self
@@ -446,6 +460,31 @@ impl RelationBuilder {
             Some(TableFactorBuilder::Unnest(ref mut rel_builder)) => {
                 rel_builder.alias = value;
             }
+            Some(TableFactorBuilder::Function(ref mut rel_builder)) => {
+                rel_builder.alias = value;
+            }
+            Some(TableFactorBuilder::TableFunction(ref mut rel_builder)) => {
+                if let Some(value) = &value {
+                    if let Some(alias) = rel_builder.alias.as_mut() {
+                        if alias
+                            .name
+                            .value
+                            .starts_with(UNNAMED_FLATTEN_SUBQUERY_PREFIX)
+                            && value.columns.len() == 1
+                        {
+                            let mut new_columns = alias.columns.clone();
+                            new_columns[4] = value.columns[0].clone();
+                            let new_alias = ast::TableAlias {
+                                name: value.name.clone(),
+                                columns: new_columns,
+                            };
+                            rel_builder.alias = Some(new_alias);
+                            return new;
+                        }
+                    }
+                }
+                rel_builder.alias = value;
+            }
             Some(TableFactorBuilder::Empty) => (),
             None => (),
         }
@@ -456,6 +495,8 @@ impl RelationBuilder {
             Some(TableFactorBuilder::Table(ref value)) => Some(value.build()?),
             Some(TableFactorBuilder::Derived(ref value)) => Some(value.build()?),
             Some(TableFactorBuilder::Unnest(ref value)) => Some(value.build()?),
+            Some(TableFactorBuilder::Function(ref value)) => Some(value.build()?),
+            Some(TableFactorBuilder::TableFunction(ref value)) => Some(value.build()?),
             Some(TableFactorBuilder::Empty) => None,
             None => return Err(Into::into(UninitializedFieldError::from("relation"))),
         })
@@ -657,6 +698,96 @@ impl UnnestRelationBuilder {
 }
 
 impl Default for UnnestRelationBuilder {
+    fn default() -> Self {
+        Self::create_empty()
+    }
+}
+
+#[derive(Clone)]
+pub struct FunctionRelationBuilder {
+    lateral: bool,
+    name: ast::ObjectName,
+    args: Vec<ast::FunctionArg>,
+    alias: Option<ast::TableAlias>,
+}
+
+#[allow(dead_code)]
+impl FunctionRelationBuilder {
+    pub fn lateral(&mut self, value: bool) -> &mut Self {
+        self.lateral = value;
+        self
+    }
+
+    pub fn name(&mut self, value: ast::ObjectName) -> &mut Self {
+        self.name = value;
+        self
+    }
+
+    pub fn args(&mut self, value: Vec<ast::FunctionArg>) -> &mut Self {
+        self.args = value;
+        self
+    }
+
+    pub fn alias(&mut self, value: Option<ast::TableAlias>) -> &mut Self {
+        self.alias = value;
+        self
+    }
+
+    pub fn build(&self) -> Result<ast::TableFactor, BuilderError> {
+        Ok(ast::TableFactor::Function {
+            lateral: self.lateral,
+            name: self.name.clone(),
+            args: self.args.clone(),
+            alias: self.alias.clone(),
+        })
+    }
+
+    fn create_empty() -> Self {
+        Self {
+            lateral: Default::default(),
+            name: ast::ObjectName(vec![]),
+            args: Default::default(),
+            alias: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct TableFunctionRelationBuilder {
+    expr: Option<ast::Expr>,
+    alias: Option<ast::TableAlias>,
+}
+
+impl TableFunctionRelationBuilder {
+    pub fn expr(&mut self, value: ast::Expr) -> &mut Self {
+        self.expr = Some(value);
+        self
+    }
+
+    pub fn alias(&mut self, value: Option<ast::TableAlias>) -> &mut Self {
+        self.alias = value;
+        self
+    }
+
+    pub fn build(&self) -> Result<ast::TableFactor, BuilderError> {
+        Ok(ast::TableFactor::TableFunction {
+            expr: match self.expr {
+                Some(ref value) => value.clone(),
+                None => return Err(Into::into(UninitializedFieldError::from("expr"))),
+            },
+            alias: self.alias.clone(),
+        })
+    }
+
+    fn create_empty() -> Self {
+        Self {
+            expr: Default::default(),
+            alias: Default::default(),
+        }
+    }
+}
+
+impl Default for TableFunctionRelationBuilder {
     fn default() -> Self {
         Self::create_empty()
     }

--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -21,8 +21,6 @@ use std::ops::ControlFlow;
 use sqlparser::ast::helpers::attached_token::AttachedToken;
 use sqlparser::ast::{self, visit_expressions_mut, OrderByKind, SelectFlavor};
 
-use crate::unparser::utils::UNNAMED_FLATTEN_SUBQUERY_PREFIX;
-
 #[derive(Clone)]
 pub struct QueryBuilder {
     with: Option<ast::With>,
@@ -400,13 +398,13 @@ impl Default for TableWithJoinsBuilder {
 
 #[derive(Clone)]
 pub struct RelationBuilder {
-    relation: Option<TableFactorBuilder>,
+    pub relation: Option<TableFactorBuilder>,
 }
 
 #[allow(dead_code)]
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum TableFactorBuilder {
+pub enum TableFactorBuilder {
     Table(TableRelationBuilder),
     Derived(DerivedRelationBuilder),
     Unnest(UnnestRelationBuilder),
@@ -464,25 +462,6 @@ impl RelationBuilder {
                 rel_builder.alias = value;
             }
             Some(TableFactorBuilder::TableFunction(ref mut rel_builder)) => {
-                if let Some(value) = &value {
-                    if let Some(alias) = rel_builder.alias.as_mut() {
-                        if alias
-                            .name
-                            .value
-                            .starts_with(UNNAMED_FLATTEN_SUBQUERY_PREFIX)
-                            && value.columns.len() == 1
-                        {
-                            let mut new_columns = alias.columns.clone();
-                            new_columns[4] = value.columns[0].clone();
-                            let new_alias = ast::TableAlias {
-                                name: value.name.clone(),
-                                columns: new_columns,
-                            };
-                            rel_builder.alias = Some(new_alias);
-                            return new;
-                        }
-                    }
-                }
                 rel_builder.alias = value;
             }
             Some(TableFactorBuilder::Empty) => (),
@@ -754,8 +733,8 @@ impl FunctionRelationBuilder {
 
 #[derive(Clone)]
 pub struct TableFunctionRelationBuilder {
-    expr: Option<ast::Expr>,
-    alias: Option<ast::TableAlias>,
+    pub expr: Option<ast::Expr>,
+    pub alias: Option<ast::TableAlias>,
 }
 
 impl TableFunctionRelationBuilder {

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -17,14 +17,19 @@
 
 use std::{collections::HashMap, sync::Arc};
 
+use crate::unparser::ast::{
+    RelationBuilder, TableFactorBuilder, TableFunctionRelationBuilder,
+};
+
 use super::{
     utils::character_length_to_sql, utils::date_part_to_sql,
     utils::sqlite_date_trunc_to_sql, utils::sqlite_from_unixtime_to_sql, Unparser,
 };
 use arrow::datatypes::TimeUnit;
-use datafusion_common::Result;
-use datafusion_expr::Expr;
+use datafusion_common::{plan_err, Result};
+use datafusion_expr::{Expr, LogicalPlan, Unnest};
 use regex::Regex;
+use sqlparser::ast::ValueWithSpan;
 use sqlparser::tokenizer::Span;
 use sqlparser::{
     ast::{
@@ -198,9 +203,32 @@ pub trait Dialect: Send + Sync {
         false
     }
 
-    /// Allow the dialect to unparse UNNEST to a Snowflake FLATTEN table factor.
+    /// Allow the dialect implement to unparse the unnest plan as the dialect-specific flattened
+    /// array table factor.
+    ///
+    /// Some dialects like Snowflake require FLATTEN function to unnest arrays in the FROM clause.
     /// <https://docs.snowflake.com/en/sql-reference/functions/flatten#syntax>
-    fn unnest_to_snowflake_flattened_array_table_factor(&self) -> bool {
+    fn unparse_unnest_table_factor(
+        &self,
+        _unnest: &Unnest,
+        _columns: &[Ident],
+        _unparser: &Unparser,
+    ) -> Result<Option<TableFactorBuilder>> {
+        Ok(None)
+    }
+
+    /// Allows the dialect to override relation alias unparsing if the dialect has specific rules.
+    /// Returns true if the dialect has overridden the alias unparsing, false to use default unparsing.
+    ///
+    /// This is useful for dialects that need to modify the alias based on specific conditions. For example,
+    /// in Snowflake, when using the FLATTEN function, the alias of the derived table needs to be adjusted
+    /// to match the output columns of the FLATTEN function. It can be used with [`unparse_unnest_table_factor`] to achieve this.
+    /// See [`SnowflakeDialect`] implementation for an example.
+    fn relation_alias_overrides(
+        &self,
+        _relation_builder: &mut RelationBuilder,
+        _alias: Option<&ast::TableAlias>,
+    ) -> bool {
         false
     }
 
@@ -582,6 +610,161 @@ impl Dialect for MsSqlDialect {
     }
 }
 
+pub static UNNAMED_SNOWFLAKE_FLATTEN_SUBQUERY_PREFIX: &str = "__unnamed_flatten_subquery";
+
+#[derive(Default)]
+pub struct SnowflakeDialect {}
+
+impl Dialect for SnowflakeDialect {
+    fn identifier_quote_style(&self, _: &str) -> Option<char> {
+        Some('"')
+    }
+
+    fn unnest_as_table_factor(&self) -> bool {
+        true
+    }
+
+    fn unparse_unnest_table_factor(
+        &self,
+        unnest: &Unnest,
+        columns: &[Ident],
+        unparser: &Unparser,
+    ) -> Result<Option<TableFactorBuilder>> {
+        let LogicalPlan::Projection(projection) = unnest.input.as_ref() else {
+            return Ok(None);
+        };
+
+        if !matches!(projection.input.as_ref(), LogicalPlan::EmptyRelation(_)) {
+            // It may be possible that UNNEST is used as a source for the query.
+            // However, at this point, we don't yet know if it is just a single expression
+            // from another source or if it's from UNNEST.
+            //
+            // Unnest(Projection(EmptyRelation)) denotes a case with `UNNEST([...])`,
+            // which is normally safe to unnest as a table factor.
+            // However, in the future, more comprehensive checks can be added here.
+            return Ok(None);
+        };
+
+        let mut table_function_relation = TableFunctionRelationBuilder::default();
+        let mut exprs = projection
+            .expr
+            .iter()
+            .map(|e| unparser.expr_to_sql(e))
+            .collect::<Result<Vec<_>>>()?;
+
+        if exprs.len() != 1 {
+            // Snowflake FLATTEN function only supports a single argument.
+            return plan_err!(
+                "Only support one argument for Snowflake FLATTEN, found {}",
+                exprs.len()
+            );
+        }
+
+        if columns.len() != 1 {
+            // Snowflake FLATTEN function only supports a single output column.
+            return plan_err!(
+                "Only support one output column for Snowflake FLATTEN, found {}",
+                columns.len()
+            );
+        }
+
+        exprs.extend(vec![
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::SingleQuotedString("".to_string()),
+                span: Span::empty(),
+            }),
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::Boolean(false),
+                span: Span::empty(),
+            }),
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::Boolean(false),
+                span: Span::empty(),
+            }),
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::SingleQuotedString("ARRAY".to_string()),
+                span: Span::empty(),
+            }),
+        ]);
+
+        // To get the flattened result, we need to override the output columns of the FLATTEN function.
+        // The 4th column corresponds to the flattened value, which we will alias to the desired output column name.
+        // https://docs.snowflake.com/en/sql-reference/functions/flatten#output
+        let column_alias = vec![
+            unparser.new_ident_quoted_if_needs("SEQ".to_string()),
+            unparser.new_ident_quoted_if_needs("KEY".to_string()),
+            unparser.new_ident_quoted_if_needs("PATH".to_string()),
+            unparser.new_ident_quoted_if_needs("INDEX".to_string()),
+            columns[0].clone(),
+            unparser.new_ident_quoted_if_needs("THIS".to_string()),
+        ];
+
+        let func_expr = ast::Expr::Function(Function {
+            name: vec![Ident::new("FLATTEN")].into(),
+            uses_odbc_syntax: false,
+            parameters: ast::FunctionArguments::None,
+            args: ast::FunctionArguments::List(ast::FunctionArgumentList {
+                args: exprs
+                    .into_iter()
+                    .map(|e| ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(e)))
+                    .collect(),
+                duplicate_treatment: None,
+                clauses: vec![],
+            }),
+            filter: None,
+            null_treatment: None,
+            over: None,
+            within_group: vec![],
+        });
+        table_function_relation.expr(func_expr);
+        table_function_relation.alias(Some(
+            unparser.new_table_alias(
+                unparser
+                    .alias_generator
+                    .next(UNNAMED_SNOWFLAKE_FLATTEN_SUBQUERY_PREFIX),
+                column_alias,
+            ),
+        ));
+        Ok(Some(TableFactorBuilder::TableFunction(
+            table_function_relation,
+        )))
+    }
+
+    fn relation_alias_overrides(
+        &self,
+        relation_builder: &mut RelationBuilder,
+        alias: Option<&ast::TableAlias>,
+    ) -> bool {
+        // When using FLATTEN function, we need to adjust the alias of the derived table
+        // to match the output columns of the FLATTEN function. The 4th column corresponds
+        // to the flattened value, which we will alias to the desired output column name.
+        if let Some(TableFactorBuilder::TableFunction(rel_builder)) =
+            relation_builder.relation.as_mut()
+        {
+            if let Some(value) = &alias {
+                if let Some(alias) = rel_builder.alias.as_mut() {
+                    if alias
+                        .name
+                        .value
+                        .starts_with(UNNAMED_SNOWFLAKE_FLATTEN_SUBQUERY_PREFIX)
+                        && value.columns.len() == 1
+                    {
+                        let mut new_columns = alias.columns.clone();
+                        new_columns[4] = value.columns[0].clone();
+                        let new_alias = ast::TableAlias {
+                            name: value.name.clone(),
+                            columns: new_columns,
+                        };
+                        rel_builder.alias = Some(new_alias);
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+}
+
 pub struct CustomDialect {
     identifier_quote_style: Option<char>,
     supports_nulls_first_in_sort: bool,
@@ -603,7 +786,6 @@ pub struct CustomDialect {
     window_func_support_window_frame: bool,
     full_qualified_col: bool,
     unnest_as_table_factor: bool,
-    unnest_to_flattened_table_factor: bool,
 }
 
 impl Default for CustomDialect {
@@ -632,7 +814,6 @@ impl Default for CustomDialect {
             window_func_support_window_frame: true,
             full_qualified_col: false,
             unnest_as_table_factor: false,
-            unnest_to_flattened_table_factor: false,
         }
     }
 }
@@ -754,10 +935,6 @@ impl Dialect for CustomDialect {
     fn unnest_as_table_factor(&self) -> bool {
         self.unnest_as_table_factor
     }
-
-    fn unnest_to_snowflake_flattened_array_table_factor(&self) -> bool {
-        self.unnest_to_flattened_table_factor
-    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -857,7 +1034,6 @@ impl CustomDialectBuilder {
             window_func_support_window_frame: self.window_func_support_window_frame,
             full_qualified_col: self.full_qualified_col,
             unnest_as_table_factor: self.unnest_as_table_factor,
-            unnest_to_flattened_table_factor: self.unnest_to_flattened_table_factor,
         }
     }
 

--- a/datafusion/sql/src/unparser/dialect.rs
+++ b/datafusion/sql/src/unparser/dialect.rs
@@ -198,6 +198,12 @@ pub trait Dialect: Send + Sync {
         false
     }
 
+    /// Allow the dialect to unparse UNNEST to a Snowflake FLATTEN table factor.
+    /// <https://docs.snowflake.com/en/sql-reference/functions/flatten#syntax>
+    fn unnest_to_snowflake_flattened_array_table_factor(&self) -> bool {
+        false
+    }
+
     /// Allows the dialect to override column alias unparsing if the dialect has specific rules.
     /// Returns None if the default unparsing should be used, or Some(String) if there is
     /// a custom implementation for the alias.
@@ -597,6 +603,7 @@ pub struct CustomDialect {
     window_func_support_window_frame: bool,
     full_qualified_col: bool,
     unnest_as_table_factor: bool,
+    unnest_to_flattened_table_factor: bool,
 }
 
 impl Default for CustomDialect {
@@ -625,6 +632,7 @@ impl Default for CustomDialect {
             window_func_support_window_frame: true,
             full_qualified_col: false,
             unnest_as_table_factor: false,
+            unnest_to_flattened_table_factor: false,
         }
     }
 }
@@ -746,6 +754,10 @@ impl Dialect for CustomDialect {
     fn unnest_as_table_factor(&self) -> bool {
         self.unnest_as_table_factor
     }
+
+    fn unnest_to_snowflake_flattened_array_table_factor(&self) -> bool {
+        self.unnest_to_flattened_table_factor
+    }
 }
 
 /// `CustomDialectBuilder` to build `CustomDialect` using builder pattern
@@ -783,6 +795,7 @@ pub struct CustomDialectBuilder {
     window_func_support_window_frame: bool,
     full_qualified_col: bool,
     unnest_as_table_factor: bool,
+    unnest_to_flattened_table_factor: bool,
 }
 
 impl Default for CustomDialectBuilder {
@@ -817,6 +830,7 @@ impl CustomDialectBuilder {
             window_func_support_window_frame: true,
             full_qualified_col: false,
             unnest_as_table_factor: false,
+            unnest_to_flattened_table_factor: false,
         }
     }
 
@@ -843,6 +857,7 @@ impl CustomDialectBuilder {
             window_func_support_window_frame: self.window_func_support_window_frame,
             full_qualified_col: self.full_qualified_col,
             unnest_as_table_factor: self.unnest_as_table_factor,
+            unnest_to_flattened_table_factor: self.unnest_to_flattened_table_factor,
         }
     }
 
@@ -981,6 +996,14 @@ impl CustomDialectBuilder {
 
     pub fn with_unnest_as_table_factor(mut self, unnest_as_table_factor: bool) -> Self {
         self.unnest_as_table_factor = unnest_as_table_factor;
+        self
+    }
+
+    pub fn with_unnest_to_flattened_table_factor(
+        mut self,
+        unnest_to_flattened_table_factor: bool,
+    ) -> Self {
+        self.unnest_to_flattened_table_factor = unnest_to_flattened_table_factor;
         self
     }
 }

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -813,7 +813,6 @@ impl Unparser<'_> {
             .collect::<Result<Vec<_>>>()
     }
 
-    /// This function can create an identifier with or without quotes based on the dialect rules
     pub(super) fn new_ident_quoted_if_needs(&self, ident: String) -> Ident {
         let quote_style = self.dialect.identifier_quote_style(&ident);
         Ident {

--- a/datafusion/sql/src/unparser/expr.rs
+++ b/datafusion/sql/src/unparser/expr.rs
@@ -813,7 +813,7 @@ impl Unparser<'_> {
             .collect::<Result<Vec<_>>>()
     }
 
-    pub(super) fn new_ident_quoted_if_needs(&self, ident: String) -> Ident {
+    pub fn new_ident_quoted_if_needs(&self, ident: String) -> Ident {
         let quote_style = self.dialect.identifier_quote_style(&ident);
         Ident {
             value: ident,

--- a/datafusion/sql/src/unparser/mod.rs
+++ b/datafusion/sql/src/unparser/mod.rs
@@ -25,6 +25,7 @@ mod utils;
 
 use self::dialect::{DefaultDialect, Dialect};
 use crate::unparser::extension_unparser::UserDefinedLogicalNodeUnparser;
+use datafusion_common::alias::AliasGenerator;
 pub use expr::expr_to_sql;
 pub use plan::plan_to_sql;
 use std::sync::Arc;
@@ -58,6 +59,7 @@ pub struct Unparser<'a> {
     dialect: &'a dyn Dialect,
     pretty: bool,
     extension_unparsers: Vec<Arc<dyn UserDefinedLogicalNodeUnparser>>,
+    alias_generator: AliasGenerator,
 }
 
 impl<'a> Unparser<'a> {
@@ -66,6 +68,7 @@ impl<'a> Unparser<'a> {
             dialect,
             pretty: false,
             extension_unparsers: vec![],
+            alias_generator: AliasGenerator::new(),
         }
     }
 
@@ -136,6 +139,7 @@ impl Default for Unparser<'_> {
             dialect: &DefaultDialect {},
             pretty: false,
             extension_unparsers: vec![],
+            alias_generator: AliasGenerator::new(),
         }
     }
 }

--- a/datafusion/sql/src/unparser/mod.rs
+++ b/datafusion/sql/src/unparser/mod.rs
@@ -59,7 +59,7 @@ pub struct Unparser<'a> {
     dialect: &'a dyn Dialect,
     pretty: bool,
     extension_unparsers: Vec<Arc<dyn UserDefinedLogicalNodeUnparser>>,
-    alias_generator: AliasGenerator,
+    pub alias_generator: AliasGenerator,
 }
 
 impl<'a> Unparser<'a> {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -31,17 +31,14 @@ use super::{
     },
     Unparser,
 };
+use crate::unparser::ast::{TableFactorBuilder, UnnestRelationBuilder};
 use crate::unparser::extension_unparser::{
     UnparseToStatementResult, UnparseWithinStatementResult,
 };
 use crate::unparser::utils::{find_unnest_node_until_relation, unproject_agg_exprs};
-use crate::unparser::{
-    ast::{TableFactorBuilder, TableFunctionRelationBuilder, UnnestRelationBuilder},
-    utils::UNNAMED_FLATTEN_SUBQUERY_PREFIX,
-};
 use crate::utils::UNNEST_PLACEHOLDER;
 use datafusion_common::{
-    internal_err, not_impl_err, plan_err,
+    internal_err, not_impl_err,
     tree_node::{TransformedResult, TreeNode},
     Column, DataFusionError, Result, ScalarValue, TableReference,
 };
@@ -51,13 +48,7 @@ use datafusion_expr::{
     LogicalPlanBuilder, Operator, Projection, SortExpr, TableScan, Unnest,
     UserDefinedLogicalNode,
 };
-use sqlparser::{
-    ast::{
-        self, Function, FunctionArgumentList, Ident, OrderByKind, SetExpr,
-        TableAliasColumnDef, ValueWithSpan,
-    },
-    tokenizer::Span,
-};
+use sqlparser::ast::{self, Ident, OrderByKind, SetExpr, TableAliasColumnDef};
 use std::{sync::Arc, vec};
 
 /// Convert a DataFusion [`LogicalPlan`] to [`ast::Statement`]
@@ -877,10 +868,16 @@ impl Unparser<'_> {
                     self.select_to_sql_recursively(&plan, query, select, relation)?;
                 }
 
-                relation.alias(Some(
-                    self.new_table_alias(plan_alias.alias.table().to_string(), columns),
-                ));
+                let new_alias =
+                    self.new_table_alias(plan_alias.alias.table().to_string(), columns);
 
+                if self
+                    .dialect
+                    .relation_alias_overrides(relation, Some(&new_alias))
+                {
+                    return Ok(());
+                }
+                relation.alias(Some(new_alias));
                 Ok(())
             }
             LogicalPlan::Union(union) => {
@@ -1047,18 +1044,14 @@ impl Unparser<'_> {
         unnest: &Unnest,
         columns: &[Ident],
     ) -> Result<Option<TableFactorBuilder>> {
-        if self
+        let dialect_flatten_relation = self
             .dialect
-            .unnest_to_snowflake_flattened_array_table_factor()
-        {
-            if let Some(flatten_relation) =
-                self.try_unnest_to_falttened_array_table_factor(unnest, columns)?
-            {
-                return Ok(Some(TableFactorBuilder::TableFunction(flatten_relation)));
-            }
-        } else if let Some(unnest_relation) =
-            self.try_unnest_to_table_factor_sql(unnest)?
-        {
+            .unparse_unnest_table_factor(unnest, columns, self)?;
+        if dialect_flatten_relation.is_some() {
+            return Ok(dialect_flatten_relation);
+        }
+
+        if let Some(unnest_relation) = self.try_unnest_to_table_factor_sql(unnest)? {
             return Ok(Some(TableFactorBuilder::Unnest(unnest_relation)));
         }
         Ok(None)
@@ -1092,105 +1085,6 @@ impl Unparser<'_> {
         unnest_relation.array_exprs(exprs);
 
         Ok(Some(unnest_relation))
-    }
-
-    fn try_unnest_to_falttened_array_table_factor(
-        &self,
-        unnest: &Unnest,
-        columns: &[Ident],
-    ) -> Result<Option<TableFunctionRelationBuilder>> {
-        let LogicalPlan::Projection(projection) = unnest.input.as_ref() else {
-            return Ok(None);
-        };
-
-        if !matches!(projection.input.as_ref(), LogicalPlan::EmptyRelation(_)) {
-            // It may be possible that UNNEST is used as a source for the query.
-            // However, at this point, we don't yet know if it is just a single expression
-            // from another source or if it's from UNNEST.
-            //
-            // Unnest(Projection(EmptyRelation)) denotes a case with `UNNEST([...])`,
-            // which is normally safe to unnest as a table factor.
-            // However, in the future, more comprehensive checks can be added here.
-            return Ok(None);
-        };
-
-        let mut table_function_relation = TableFunctionRelationBuilder::default();
-        let mut exprs = projection
-            .expr
-            .iter()
-            .map(|e| self.expr_to_sql(e))
-            .collect::<Result<Vec<_>>>()?;
-
-        if exprs.len() != 1 {
-            // Snowflake FLATTEN function only supports a single argument.
-            return plan_err!(
-                "Only support one argument for Snowflake FLATTEN, found {}",
-                exprs.len()
-            );
-        }
-
-        if columns.len() != 1 {
-            // Snowflake FLATTEN function only supports a single output column.
-            return plan_err!(
-                "Only support one output column for Snowflake FLATTEN, found {}",
-                columns.len()
-            );
-        }
-
-        exprs.extend(vec![
-            ast::Expr::Value(ValueWithSpan {
-                value: ast::Value::SingleQuotedString("".to_string()),
-                span: Span::empty(),
-            }),
-            ast::Expr::Value(ValueWithSpan {
-                value: ast::Value::Boolean(false),
-                span: Span::empty(),
-            }),
-            ast::Expr::Value(ValueWithSpan {
-                value: ast::Value::Boolean(false),
-                span: Span::empty(),
-            }),
-            ast::Expr::Value(ValueWithSpan {
-                value: ast::Value::SingleQuotedString("ARRAY".to_string()),
-                span: Span::empty(),
-            }),
-        ]);
-
-        // To get the flattened result, we need to override the output columns of the FLATTEN function.
-        // The 4th column corresponds to the flattened value, which we will alias to the desired output column name.
-        // https://docs.snowflake.com/en/sql-reference/functions/flatten#output
-        let column_alias = vec![
-            self.new_ident_quoted_if_needs("SEQ".to_string()),
-            self.new_ident_quoted_if_needs("KEY".to_string()),
-            self.new_ident_quoted_if_needs("PATH".to_string()),
-            self.new_ident_quoted_if_needs("INDEX".to_string()),
-            columns[0].clone(),
-            self.new_ident_quoted_if_needs("THIS".to_string()),
-        ];
-
-        let func_expr = ast::Expr::Function(Function {
-            name: vec![Ident::new("FLATTEN")].into(),
-            uses_odbc_syntax: false,
-            parameters: ast::FunctionArguments::None,
-            args: ast::FunctionArguments::List(FunctionArgumentList {
-                args: exprs
-                    .into_iter()
-                    .map(|e| ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(e)))
-                    .collect(),
-                duplicate_treatment: None,
-                clauses: vec![],
-            }),
-            filter: None,
-            null_treatment: None,
-            over: None,
-            within_group: vec![],
-        });
-        table_function_relation.expr(func_expr);
-        table_function_relation.alias(Some(self.new_table_alias(
-            self.alias_generator.next(UNNAMED_FLATTEN_SUBQUERY_PREFIX),
-            column_alias,
-        )));
-        Ok(Some(table_function_relation))
     }
 
     fn is_scan_with_pushdown(scan: &TableScan) -> bool {
@@ -1535,7 +1429,7 @@ impl Unparser<'_> {
         self.binary_op_to_sql(lhs, rhs, ast::BinaryOperator::And)
     }
 
-    fn new_table_alias(&self, alias: String, columns: Vec<Ident>) -> ast::TableAlias {
+    pub fn new_table_alias(&self, alias: String, columns: Vec<Ident>) -> ast::TableAlias {
         let columns = columns
             .into_iter()
             .map(|ident| TableAliasColumnDef {

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -1056,7 +1056,9 @@ impl Unparser<'_> {
             {
                 return Ok(Some(TableFactorBuilder::TableFunction(flatten_relation)));
             }
-        } else if let Some(unnest_relation) = self.try_unnest_to_table_factor_sql(unnest)? {
+        } else if let Some(unnest_relation) =
+            self.try_unnest_to_table_factor_sql(unnest)?
+        {
             return Ok(Some(TableFactorBuilder::Unnest(unnest_relation)));
         }
         Ok(None)

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -22,8 +22,7 @@ use super::{
     },
     rewrite::{
         inject_column_aliases_into_subquery, normalize_union_schema,
-        rewrite_plan_for_sort_on_non_projected_fields,
-        subquery_alias_inner_query_and_columns, TableAliasRewriter,
+        rewrite_plan_for_sort_on_non_projected_fields, TableAliasRewriter,
     },
     utils::{
         find_agg_node_within_select, find_unnest_node_within_select,
@@ -32,14 +31,17 @@ use super::{
     },
     Unparser,
 };
-use crate::unparser::ast::UnnestRelationBuilder;
 use crate::unparser::extension_unparser::{
     UnparseToStatementResult, UnparseWithinStatementResult,
 };
 use crate::unparser::utils::{find_unnest_node_until_relation, unproject_agg_exprs};
+use crate::unparser::{
+    ast::{TableFactorBuilder, TableFunctionRelationBuilder, UnnestRelationBuilder},
+    utils::UNNAMED_FLATTEN_SUBQUERY_PREFIX,
+};
 use crate::utils::UNNEST_PLACEHOLDER;
 use datafusion_common::{
-    internal_err, not_impl_err,
+    internal_err, not_impl_err, plan_err,
     tree_node::{TransformedResult, TreeNode},
     Column, DataFusionError, Result, ScalarValue, TableReference,
 };
@@ -49,7 +51,13 @@ use datafusion_expr::{
     LogicalPlanBuilder, Operator, Projection, SortExpr, TableScan, Unnest,
     UserDefinedLogicalNode,
 };
-use sqlparser::ast::{self, Ident, OrderByKind, SetExpr, TableAliasColumnDef};
+use sqlparser::{
+    ast::{
+        self, Function, FunctionArgumentList, Ident, OrderByKind, SetExpr,
+        TableAliasColumnDef, ValueWithSpan,
+    },
+    tokenizer::Span,
+};
 use std::{sync::Arc, vec};
 
 /// Convert a DataFusion [`LogicalPlan`] to [`ast::Statement`]
@@ -377,21 +385,6 @@ impl Unparser<'_> {
                 } else {
                     None
                 };
-                if self.dialect.unnest_as_table_factor() && unnest_input_type.is_some() {
-                    if let LogicalPlan::Unnest(unnest) = &p.input.as_ref() {
-                        if let Some(unnest_relation) =
-                            self.try_unnest_to_table_factor_sql(unnest)?
-                        {
-                            relation.unnest(unnest_relation);
-                            return self.select_to_sql_recursively(
-                                p.input.as_ref(),
-                                query,
-                                select,
-                                relation,
-                            );
-                        }
-                    }
-                }
 
                 // If it's a unnest projection, we should provide the table column alias
                 // to provide a column name for the unnest relation.
@@ -405,6 +398,36 @@ impl Unparser<'_> {
                 } else {
                     vec![]
                 };
+
+                if self.dialect.unnest_as_table_factor() && unnest_input_type.is_some() {
+                    if let LogicalPlan::Unnest(unnest) = &p.input.as_ref() {
+                        if let Some(table_factor) =
+                            self.unparse_unnest_table_factor(unnest, &columns)?
+                        {
+                            match table_factor {
+                                TableFactorBuilder::Unnest(unnest) => {
+                                    relation.unnest(unnest)
+                                }
+                                TableFactorBuilder::TableFunction(table_function) => {
+                                    relation.table_function(table_function)
+                                }
+                                _ => {
+                                    return internal_err!(
+                                        "Unexpected table factor type for unnest"
+                                    );
+                                }
+                            };
+
+                            return self.select_to_sql_recursively(
+                                p.input.as_ref(),
+                                query,
+                                select,
+                                relation,
+                            );
+                        }
+                    }
+                }
+
                 // Projection can be top-level plan for derived table
                 if select.already_projected() {
                     return self.derive_with_dialect_alias(
@@ -814,7 +837,7 @@ impl Unparser<'_> {
             }
             LogicalPlan::SubqueryAlias(plan_alias) => {
                 let (plan, mut columns) =
-                    subquery_alias_inner_query_and_columns(plan_alias);
+                    self.subquery_alias_inner_query_and_columns(plan_alias);
                 let unparsed_table_scan = Self::unparse_table_scan_pushdown(
                     plan,
                     Some(plan_alias.alias.clone()),
@@ -1019,6 +1042,26 @@ impl Unparser<'_> {
         None
     }
 
+    fn unparse_unnest_table_factor(
+        &self,
+        unnest: &Unnest,
+        columns: &[Ident],
+    ) -> Result<Option<TableFactorBuilder>> {
+        if self
+            .dialect
+            .unnest_to_snowflake_flattened_array_table_factor()
+        {
+            if let Some(flatten_relation) =
+                self.try_unnest_to_falttened_array_table_factor(unnest, columns)?
+            {
+                return Ok(Some(TableFactorBuilder::TableFunction(flatten_relation)));
+            }
+        } else if let Some(unnest_relation) = self.try_unnest_to_table_factor_sql(unnest)? {
+            return Ok(Some(TableFactorBuilder::Unnest(unnest_relation)));
+        }
+        Ok(None)
+    }
+
     fn try_unnest_to_table_factor_sql(
         &self,
         unnest: &Unnest,
@@ -1047,6 +1090,105 @@ impl Unparser<'_> {
         unnest_relation.array_exprs(exprs);
 
         Ok(Some(unnest_relation))
+    }
+
+    fn try_unnest_to_falttened_array_table_factor(
+        &self,
+        unnest: &Unnest,
+        columns: &[Ident],
+    ) -> Result<Option<TableFunctionRelationBuilder>> {
+        let LogicalPlan::Projection(projection) = unnest.input.as_ref() else {
+            return Ok(None);
+        };
+
+        if !matches!(projection.input.as_ref(), LogicalPlan::EmptyRelation(_)) {
+            // It may be possible that UNNEST is used as a source for the query.
+            // However, at this point, we don't yet know if it is just a single expression
+            // from another source or if it's from UNNEST.
+            //
+            // Unnest(Projection(EmptyRelation)) denotes a case with `UNNEST([...])`,
+            // which is normally safe to unnest as a table factor.
+            // However, in the future, more comprehensive checks can be added here.
+            return Ok(None);
+        };
+
+        let mut table_function_relation = TableFunctionRelationBuilder::default();
+        let mut exprs = projection
+            .expr
+            .iter()
+            .map(|e| self.expr_to_sql(e))
+            .collect::<Result<Vec<_>>>()?;
+
+        if exprs.len() != 1 {
+            // Snowflake FLATTEN function only supports a single argument.
+            return plan_err!(
+                "Only support one argument for Snowflake FLATTEN, found {}",
+                exprs.len()
+            );
+        }
+
+        if columns.len() != 1 {
+            // Snowflake FLATTEN function only supports a single output column.
+            return plan_err!(
+                "Only support one output column for Snowflake FLATTEN, found {}",
+                columns.len()
+            );
+        }
+
+        exprs.extend(vec![
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::SingleQuotedString("".to_string()),
+                span: Span::empty(),
+            }),
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::Boolean(false),
+                span: Span::empty(),
+            }),
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::Boolean(false),
+                span: Span::empty(),
+            }),
+            ast::Expr::Value(ValueWithSpan {
+                value: ast::Value::SingleQuotedString("ARRAY".to_string()),
+                span: Span::empty(),
+            }),
+        ]);
+
+        // To get the flattened result, we need to override the output columns of the FLATTEN function.
+        // The 4th column corresponds to the flattened value, which we will alias to the desired output column name.
+        // https://docs.snowflake.com/en/sql-reference/functions/flatten#output
+        let column_alias = vec![
+            self.new_ident_quoted_if_needs("SEQ".to_string()),
+            self.new_ident_quoted_if_needs("KEY".to_string()),
+            self.new_ident_quoted_if_needs("PATH".to_string()),
+            self.new_ident_quoted_if_needs("INDEX".to_string()),
+            columns[0].clone(),
+            self.new_ident_quoted_if_needs("THIS".to_string()),
+        ];
+
+        let func_expr = ast::Expr::Function(Function {
+            name: vec![Ident::new("FLATTEN")].into(),
+            uses_odbc_syntax: false,
+            parameters: ast::FunctionArguments::None,
+            args: ast::FunctionArguments::List(FunctionArgumentList {
+                args: exprs
+                    .into_iter()
+                    .map(|e| ast::FunctionArg::Unnamed(ast::FunctionArgExpr::Expr(e)))
+                    .collect(),
+                duplicate_treatment: None,
+                clauses: vec![],
+            }),
+            filter: None,
+            null_treatment: None,
+            over: None,
+            within_group: vec![],
+        });
+        table_function_relation.expr(func_expr);
+        table_function_relation.alias(Some(self.new_table_alias(
+            self.alias_generator.next(UNNAMED_FLATTEN_SUBQUERY_PREFIX),
+            column_alias,
+        )));
+        Ok(Some(table_function_relation))
     }
 
     fn is_scan_with_pushdown(scan: &TableScan) -> bool {

--- a/datafusion/sql/src/unparser/rewrite.rs
+++ b/datafusion/sql/src/unparser/rewrite.rs
@@ -27,6 +27,8 @@ use datafusion_expr::expr::{Alias, UNNEST_COLUMN_PREFIX};
 use datafusion_expr::{Expr, LogicalPlan, Projection, Sort, SortExpr};
 use sqlparser::ast::Ident;
 
+use crate::unparser::Unparser;
+
 /// Normalize the schema of a union plan to remove qualifiers from the schema fields and sort expressions.
 ///
 /// DataFusion will return an error if two columns in the schema have the same name with no table qualifiers.
@@ -190,83 +192,6 @@ pub(super) fn rewrite_plan_for_sort_on_non_projected_fields(
     }
 }
 
-/// This logic is to work out the columns and inner query for SubqueryAlias plan for some types of
-/// subquery or unnest
-/// - `(SELECT column_a as a from table) AS A`
-/// - `(SELECT column_a from table) AS A (a)`
-/// - `SELECT * FROM t1 CROSS JOIN UNNEST(t1.c1) AS u(c1)` (see [find_unnest_column_alias])
-///
-/// A roundtrip example for table alias with columns
-///
-/// query: SELECT id FROM (SELECT j1_id from j1) AS c (id)
-///
-/// LogicPlan:
-/// Projection: c.id
-///   SubqueryAlias: c
-///     Projection: j1.j1_id AS id
-///       Projection: j1.j1_id
-///         TableScan: j1
-///
-/// Before introducing this logic, the unparsed query would be `SELECT c.id FROM (SELECT j1.j1_id AS
-/// id FROM (SELECT j1.j1_id FROM j1)) AS c`.
-/// The query is invalid as `j1.j1_id` is not a valid identifier in the derived table
-/// `(SELECT j1.j1_id FROM j1)`
-///
-/// With this logic, the unparsed query will be:
-/// `SELECT c.id FROM (SELECT j1.j1_id FROM j1) AS c (id)`
-///
-/// Caveat: this won't handle the case like `select * from (select 1, 2) AS a (b, c)`
-/// as the parser gives a wrong plan which has mismatch `Int(1)` types: Literal and
-/// Column in the Projections. Once the parser side is fixed, this logic should work
-pub(super) fn subquery_alias_inner_query_and_columns(
-    subquery_alias: &datafusion_expr::SubqueryAlias,
-) -> (&LogicalPlan, Vec<Ident>) {
-    let plan: &LogicalPlan = subquery_alias.input.as_ref();
-
-    if let LogicalPlan::Subquery(subquery) = plan {
-        let (inner_projection, Some(column)) =
-            find_unnest_column_alias(subquery.subquery.as_ref())
-        else {
-            return (plan, vec![]);
-        };
-        return (inner_projection, vec![Ident::new(column)]);
-    }
-
-    let LogicalPlan::Projection(outer_projections) = plan else {
-        return (plan, vec![]);
-    };
-
-    // Check if it's projection inside projection
-    let Some(inner_projection) = find_projection(outer_projections.input.as_ref()) else {
-        return (plan, vec![]);
-    };
-
-    let mut columns: Vec<Ident> = vec![];
-    // Check if the inner projection and outer projection have a matching pattern like
-    //     Projection: j1.j1_id AS id
-    //       Projection: j1.j1_id
-    for (i, inner_expr) in inner_projection.expr.iter().enumerate() {
-        let Expr::Alias(ref outer_alias) = &outer_projections.expr[i] else {
-            return (plan, vec![]);
-        };
-
-        // Inner projection schema fields store the projection name which is used in outer
-        // projection expr
-        let inner_expr_string = match inner_expr {
-            Expr::Column(_) => inner_expr.to_string(),
-            _ => inner_projection.schema.field(i).name().clone(),
-        };
-
-        if outer_alias.expr.to_string() != inner_expr_string {
-            return (plan, vec![]);
-        };
-
-        columns.push(outer_alias.name.as_str().into());
-    }
-
-    (outer_projections.input.as_ref(), columns)
-}
-
 /// Try to find the column alias for UNNEST in the inner projection.
 /// For example:
 /// ```sql
@@ -380,6 +305,90 @@ fn find_projection(logical_plan: &LogicalPlan) -> Option<&Projection> {
         LogicalPlan::Distinct(p) => find_projection(p.input().as_ref()),
         LogicalPlan::Sort(p) => find_projection(p.input.as_ref()),
         _ => None,
+    }
+}
+
+impl<'a> Unparser<'a> {
+    /// This logic is to work out the columns and inner query for SubqueryAlias plan for some types of
+    /// subquery or unnest
+    /// - `(SELECT column_a as a from table) AS A`
+    /// - `(SELECT column_a from table) AS A (a)`
+    /// - `SELECT * FROM t1 CROSS JOIN UNNEST(t1.c1) AS u(c1)` (see [find_unnest_column_alias])
+    ///
+    /// A roundtrip example for table alias with columns
+    ///
+    /// query: SELECT id FROM (SELECT j1_id from j1) AS c (id)
+    ///
+    /// LogicPlan:
+    /// Projection: c.id
+    ///   SubqueryAlias: c
+    ///     Projection: j1.j1_id AS id
+    ///       Projection: j1.j1_id
+    ///         TableScan: j1
+    ///
+    /// Before introducing this logic, the unparsed query would be `SELECT c.id FROM (SELECT j1.j1_id AS
+    /// id FROM (SELECT j1.j1_id FROM j1)) AS c`.
+    /// The query is invalid as `j1.j1_id` is not a valid identifier in the derived table
+    /// `(SELECT j1.j1_id FROM j1)`
+    ///
+    /// With this logic, the unparsed query will be:
+    /// `SELECT c.id FROM (SELECT j1.j1_id FROM j1) AS c (id)`
+    ///
+    /// Caveat: this won't handle the case like `select * from (select 1, 2) AS a (b, c)`
+    /// as the parser gives a wrong plan which has mismatch `Int(1)` types: Literal and
+    /// Column in the Projections. Once the parser side is fixed, this logic should work
+    pub(super) fn subquery_alias_inner_query_and_columns(
+        &'a self,
+        subquery_alias: &'a datafusion_expr::SubqueryAlias,
+    ) -> (&'a LogicalPlan, Vec<Ident>) {
+        let plan: &LogicalPlan = subquery_alias.input.as_ref();
+
+        if let LogicalPlan::Subquery(subquery) = plan {
+            let (inner_projection, Some(column)) =
+                find_unnest_column_alias(subquery.subquery.as_ref())
+            else {
+                return (plan, vec![]);
+            };
+            return (
+                inner_projection,
+                vec![self.new_ident_quoted_if_needs(column)],
+            );
+        }
+
+        let LogicalPlan::Projection(outer_projections) = plan else {
+            return (plan, vec![]);
+        };
+
+        // Check if it's projection inside projection
+        let Some(inner_projection) = find_projection(outer_projections.input.as_ref())
+        else {
+            return (plan, vec![]);
+        };
+
+        let mut columns: Vec<Ident> = vec![];
+        // Check if the inner projection and outer projection have a matching pattern like
+        //     Projection: j1.j1_id AS id
+        //       Projection: j1.j1_id
+        for (i, inner_expr) in inner_projection.expr.iter().enumerate() {
+            let Expr::Alias(ref outer_alias) = &outer_projections.expr[i] else {
+                return (plan, vec![]);
+            };
+
+            // Inner projection schema fields store the projection name which is used in outer
+            // projection expr
+            let inner_expr_string = match inner_expr {
+                Expr::Column(_) => inner_expr.to_string(),
+                _ => inner_projection.schema.field(i).name().clone(),
+            };
+
+            if outer_alias.expr.to_string() != inner_expr_string {
+                return (plan, vec![]);
+            };
+
+            columns.push(self.new_ident_quoted_if_needs(outer_alias.name.clone()));
+        }
+
+        (outer_projections.input.as_ref(), columns)
     }
 }
 

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -35,8 +35,6 @@ use indexmap::IndexSet;
 use sqlparser::ast;
 use sqlparser::tokenizer::Span;
 
-pub static UNNAMED_FLATTEN_SUBQUERY_PREFIX: &str = "__unnamed_flatten_subquery";
-
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if exists
 /// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
 /// If an Aggregate or node is not found prior to this or at all before reaching the end

--- a/datafusion/sql/src/unparser/utils.rs
+++ b/datafusion/sql/src/unparser/utils.rs
@@ -35,6 +35,8 @@ use indexmap::IndexSet;
 use sqlparser::ast;
 use sqlparser::tokenizer::Span;
 
+pub static UNNAMED_FLATTEN_SUBQUERY_PREFIX: &str = "__unnamed_flatten_subquery";
+
 /// Recursively searches children of [LogicalPlan] to find an Aggregate node if exists
 /// prior to encountering a Join, TableScan, or a nested subquery (derived table factor).
 /// If an Aggregate or node is not found prior to this or at all before reaching the end

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2538,6 +2538,19 @@ fn test_unparse_unnest_to_table_flatten() -> Result<()> {
         @r#"SELECT "t"."a" FROM TABLE(FLATTEN([1, 2, 3], '', false, false, 'ARRAY')) AS "t" ("SEQ", "KEY", "PATH", "INDEX", "a", "THIS")"#
     );
 
+    let plan = sql_to_plan("SELECT * FROM unnest_table, UNNEST(unnest_table.array_col)")?;
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan).unwrap(),
+        @r#"SELECT "unnest_table"."array_col", "unnest_table"."struct_col", "UNNEST(outer_ref(unnest_table.array_col))" FROM "unnest_table" CROSS JOIN TABLE(FLATTEN("unnest_table"."array_col", '', false, false, 'ARRAY')) AS "__unnamed_flatten_subquery_4" ("SEQ", "KEY", "PATH", "INDEX", "UNNEST(outer_ref(unnest_table.array_col))", "THIS")"#
+    );
+
+    let plan =
+        sql_to_plan("SELECT t.a FROM unnest_table, UNNEST(unnest_table.array_col) t(a)")?;
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan).unwrap(),
+        @r#"SELECT "t"."a" FROM "unnest_table" CROSS JOIN TABLE(FLATTEN("unnest_table"."array_col", '', false, false, 'ARRAY')) AS "t" ("SEQ", "KEY", "PATH", "INDEX", "a", "THIS")"#
+    );
+
     Ok(())
 }
 

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -2518,6 +2518,48 @@ fn test_unparse_left_semi_join_with_table_scan_projection() -> Result<()> {
 }
 
 #[test]
+fn test_unparse_unnest_to_table_flatten() -> Result<()> {
+    let unparser_dialect = CustomDialectBuilder::new()
+        .with_unnest_as_table_factor(true)
+        .with_unnest_to_flattened_table_factor(true)
+        .with_identifier_quote_style('"')
+        .build();
+    let unparser = Unparser::new(&unparser_dialect);
+
+    let plan = sql_to_plan("SELECT * FROM UNNEST([1,2,3])")?;
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan).unwrap(),
+        @r#"SELECT "UNNEST(make_array(Int64(1),Int64(2),Int64(3)))" FROM TABLE(FLATTEN([1, 2, 3], '', false, false, 'ARRAY')) AS "__unnamed_flatten_subquery_1" ("SEQ", "KEY", "PATH", "INDEX", "UNNEST(make_array(Int64(1),Int64(2),Int64(3)))", "THIS")"#
+    );
+
+    let plan = sql_to_plan("SELECT * FROM UNNEST([1,2,3]) t(a)")?;
+    assert_snapshot!(
+        unparser.plan_to_sql(&plan).unwrap(),
+        @r#"SELECT "t"."a" FROM TABLE(FLATTEN([1, 2, 3], '', false, false, 'ARRAY')) AS "t" ("SEQ", "KEY", "PATH", "INDEX", "a", "THIS")"#
+    );
+
+    Ok(())
+}
+
+fn sql_to_plan(sql: &str) -> Result<LogicalPlan> {
+    let dialect = GenericDialect {};
+    let statement = Parser::new(&dialect).try_with_sql(sql)?.parse_statement()?;
+    let state = MockSessionState::default()
+        .with_aggregate_function(sum_udaf())
+        .with_aggregate_function(max_udaf())
+        .with_aggregate_function(grouping_udaf())
+        .with_window_function(rank_udwf())
+        .with_scalar_function(Arc::new(unicode::substr().as_ref().clone()))
+        .with_scalar_function(make_array_udf())
+        .with_expr_planner(Arc::new(CoreFunctionPlanner::default()))
+        .with_expr_planner(Arc::new(NestedFunctionPlanner))
+        .with_expr_planner(Arc::new(FieldAccessPlanner));
+    let context = MockContextProvider { state };
+    let sql_to_rel = SqlToRel::new(&context);
+    sql_to_rel.sql_statement_to_plan(statement)
+}
+
+#[test]
 fn test_like_filter() {
     let statement = generate_round_trip_statement(
         GenericDialect {},

--- a/datafusion/sql/tests/cases/plan_to_sql.rs
+++ b/datafusion/sql/tests/cases/plan_to_sql.rs
@@ -36,7 +36,7 @@ use datafusion_sql::planner::{ContextProvider, PlannerContext, SqlToRel};
 use datafusion_sql::unparser::dialect::{
     BigQueryDialect, CustomDialectBuilder, DefaultDialect as UnparserDefaultDialect,
     DefaultDialect, Dialect as UnparserDialect, MySqlDialect as UnparserMySqlDialect,
-    PostgreSqlDialect as UnparserPostgreSqlDialect, SqliteDialect,
+    PostgreSqlDialect as UnparserPostgreSqlDialect, SnowflakeDialect, SqliteDialect,
 };
 use datafusion_sql::unparser::{expr_to_sql, plan_to_sql, Unparser};
 use insta::assert_snapshot;
@@ -2519,11 +2519,7 @@ fn test_unparse_left_semi_join_with_table_scan_projection() -> Result<()> {
 
 #[test]
 fn test_unparse_unnest_to_table_flatten() -> Result<()> {
-    let unparser_dialect = CustomDialectBuilder::new()
-        .with_unnest_as_table_factor(true)
-        .with_unnest_to_flattened_table_factor(true)
-        .with_identifier_quote_style('"')
-        .build();
+    let unparser_dialect = SnowflakeDialect {};
     let unparser = Unparser::new(&unparser_dialect);
 
     let plan = sql_to_plan("SELECT * FROM UNNEST([1,2,3])")?;


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change
Snowflake doesn't support `UNNEST` syntax, but they use [FLATTEN](https://docs.snowflake.com/en/sql-reference/functions/flatten#syntax) instead. `FLATTEN` is a table function, and it has a different schema from the common unnest usage. We need to transform the unnest plan to fit their schema.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?
- introduce `unparse_unnest_table_factor` and `relation_alias_overrides` for unparsing unnest.
- introduce `SnowflakeDialect`.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->
