### PR TITLE
support Duration type for window framing

### DIFF
--- a/datafusion/optimizer/src/analyzer/type_coercion.rs
+++ b/datafusion/optimizer/src/analyzer/type_coercion.rs
@@ -730,6 +730,8 @@ fn extract_window_frame_target_type(col_type: &DataType) -> Result<DataType> {
         Ok(DataType::Interval(IntervalUnit::MonthDayNano))
     } else if let DataType::Dictionary(_, value_type) = col_type {
         extract_window_frame_target_type(value_type)
+    } else if let DataType::Duration(_) = col_type {
+        Ok(col_type.clone())
     } else {
         return internal_err!("Cannot run range queries on datatype: {col_type:?}");
     }

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -439,6 +439,14 @@ LIMIT 5
 781 100
 781 100
 
+# window_frame_duration_type
+WITH t1 AS (
+  SELECT now() AS c1, timestamp '2011-01-01 12:00:00' AS c2
+)
+SELECT rank() OVER (ORDER BY c2 - c1) FROM t1;
+----
+1
+
 # window_frame_rows_preceding
 query IRI
 SELECT

--- a/datafusion/sqllogictest/test_files/window.slt
+++ b/datafusion/sqllogictest/test_files/window.slt
@@ -440,6 +440,7 @@ LIMIT 5
 781 100
 
 # window_frame_duration_type
+query I
 WITH t1 AS (
   SELECT now() AS c1, timestamp '2011-01-01 12:00:00' AS c2
 )


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #.

## Rationale for this change

## What changes are included in this PR?
support `Duration` type for window framing

```sql 
WITH t1 AS (
  SELECT now() AS c1, timestamp '2011-01-01 12:00:00' AS c2
)
SELECT rank() OVER (ORDER BY c2 - c1) FROM t1;

```


## Are these changes tested?
