### PR TITLE
feat(unparser): support Function table factor for unnest

### DIFF
--- a/datafusion/sql/src/unparser/ast.rs
+++ b/datafusion/sql/src/unparser/ast.rs
@@ -731,6 +731,12 @@ impl FunctionRelationBuilder {
     }
 }
 
+impl Default for FunctionRelationBuilder {
+    fn default() -> Self {
+        Self::create_empty()
+    }
+}
+
 #[derive(Clone)]
 pub struct TableFunctionRelationBuilder {
     pub expr: Option<ast::Expr>,

--- a/datafusion/sql/src/unparser/plan.rs
+++ b/datafusion/sql/src/unparser/plan.rs
@@ -406,6 +406,9 @@ impl Unparser<'_> {
                                 TableFactorBuilder::TableFunction(table_function) => {
                                     relation.table_function(table_function)
                                 }
+                                TableFactorBuilder::Function(function) => {
+                                    relation.function(function)
+                                }
                                 _ => {
                                     return internal_err!(
                                         "Unexpected table factor type for unnest"


### PR DESCRIPTION
## Summary
- Add `TableFactorBuilder::Function` arm to the unnest table factor match in the unparser, so dialect implementations can emit `LATERAL func_name(args)` via `FunctionRelationBuilder`
- Add `Default` impl for `FunctionRelationBuilder` so dialects can construct it conveniently

## Motivation

Wren Engine's Postgres dialect needs to emit `LATERAL jsonb_array_elements(...)` when unnesting JSONB arrays from outer-referenced columns. The existing match only handles `Unnest` and `TableFunction` variants — `Function` (which carries a `lateral` flag) was missing.

## Test plan
- [ ] Existing unnest tests pass (Snowflake FLATTEN, literal UNNEST, alias validation)
- [ ] Wren Engine Postgres JSONB unnest test passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)